### PR TITLE
font optimisation

### DIFF
--- a/index.css
+++ b/index.css
@@ -46,6 +46,7 @@
     url("/fonts/SourceCodePro/SourceCodePro-Light.ttf");
   font-weight: 300;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -54,6 +55,7 @@
     url("/fonts/SourceCodePro/SourceCodePro-Medium.ttf");
   font-weight: 500;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -62,6 +64,7 @@
     url("/fonts/SourceCodePro/SourceCodePro-Bold.ttf");
   font-weight: 700;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -70,6 +73,7 @@
     url("/fonts/SourceCodePro/SourceCodePro-Black.ttf");
   font-weight: 900;
   font-style: normal;
+  font-display: swap;
 }
 
 /* ROBOTO */
@@ -78,6 +82,7 @@
   src: local("Roboto"), url("/fonts/Roboto/Roboto-Light.ttf");
   font-weight: 300;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -85,6 +90,7 @@
   src: local("Roboto"), url("/fonts/Roboto/Roboto-Regular.ttf");
   font-weight: 400;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -92,6 +98,7 @@
   src: local("Roboto"), url("/fonts/Roboto/Roboto-Medium.ttf");
   font-weight: 500;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -99,6 +106,7 @@
   src: local("Roboto"), url("/fonts/Roboto/Roboto-Bold.ttf");
   font-weight: 700;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -106,4 +114,5 @@
   src: local("Roboto"), url("/fonts/Roboto/Roboto-Black.ttf");
   font-weight: 900;
   font-style: normal;
+  font-display: swap;
 }


### PR DESCRIPTION
`font-display: swap` ensures that system font immediately renders words while custom fonts are being loaded in.