### PR TITLE
Add reusable SEO metadata component

### DIFF
--- a/src/components/Seo.astro
+++ b/src/components/Seo.astro
@@ -1,0 +1,76 @@
+---
+interface Props {
+  title: string;
+  description?: string;
+  url?: string;
+  publishedTime?: string;
+  updatedTime?: string;
+  image?: string;
+  type?: string;
+  noIndex?: boolean;
+}
+
+const {
+  title,
+  description,
+  url,
+  publishedTime,
+  updatedTime,
+  image,
+  type = "website",
+  noIndex = false,
+} = Astro.props as Props;
+
+const metaDescription =
+  description ?? "Personal website and blog. Opinions are my own.";
+
+const fallbackImage = "/icons/favicon-96x96.png";
+const imagePath = image ?? fallbackImage;
+
+const canonicalUrl = (() => {
+  const base = Astro.site ?? Astro.url;
+
+  if (url) {
+    try {
+      return new URL(url, base ?? undefined).toString();
+    } catch {
+      return undefined;
+    }
+  }
+
+  return Astro.url?.href ?? Astro.site?.toString();
+})();
+
+const openGraphImage = (() => {
+  const base = Astro.site ?? Astro.url;
+  try {
+    return new URL(imagePath, base ?? undefined).toString();
+  } catch {
+    return imagePath;
+  }
+})();
+---
+<title>{title}</title>
+{canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+<meta name="description" content={metaDescription} />
+{noIndex && <meta name="robots" content="noindex, nofollow" />}
+
+<meta property="og:title" content={title} />
+<meta property="og:description" content={metaDescription} />
+{canonicalUrl && <meta property="og:url" content={canonicalUrl} />}
+<meta property="og:type" content={type} />
+{openGraphImage && <meta property="og:image" content={openGraphImage} />}
+{publishedTime && (
+  <meta property="article:published_time" content={publishedTime} />
+)}
+{updatedTime && (
+  <meta property="article:modified_time" content={updatedTime} />
+)}
+
+<meta
+  name="twitter:card"
+  content={openGraphImage ? "summary_large_image" : "summary"}
+/>
+<meta name="twitter:title" content={title} />
+<meta name="twitter:description" content={metaDescription} />
+{openGraphImage && <meta name="twitter:image" content={openGraphImage} />}

--- a/src/layouts/ContentLayout.astro
+++ b/src/layouts/ContentLayout.astro
@@ -2,10 +2,10 @@
 import Footer from "@components/Footer.astro";
 import RootLayout from "@layouts/RootLayout.astro";
 
-const { title } = Astro.props;
+const { title, ...seoProps } = Astro.props;
 ---
 
-<RootLayout title={title}>
+<RootLayout title={title} {...seoProps}>
   <div
     class="fixed inset-0 backdrop-blur-md bg-ivory/60 dark:bg-shark-950/60 md:bg-ivory/85 md:dark:bg-shark-950/85 z-10"
   >

--- a/src/layouts/RootLayout.astro
+++ b/src/layouts/RootLayout.astro
@@ -2,30 +2,35 @@
 import DarkMode from "@components/DarkMode/DarkMode.astro";
 import Nav from "@components/Nav.astro";
 import Particles from "@components/Particles/Particles.astro";
+import Seo from "@components/Seo.astro";
 import "../styles/global.css";
 import GAnalytics from "@components/GAnalytics.astro";
 import { ClientRouter } from "astro:transitions";
 
 interface Props {
   title: string;
+  description?: string;
+  url?: string;
+  publishedTime?: string;
+  updatedTime?: string;
+  image?: string;
+  type?: string;
+  noIndex?: boolean;
 }
 
-const { title } = Astro.props;
+const { title, ...seoProps } = Astro.props as Props;
+const pageUrl = seoProps.url ?? Astro.url?.pathname ?? "/";
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta
-      name="description"
-      content="Personal website and blog. Opinions are my own."
-    />
+    <Seo title={title} {...seoProps} url={pageUrl} />
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
     <meta name="theme-color" content="#f5f5f5" id="theme-color" />
     <meta name="mobile-web-app-capable" content="yes" />
-    <title>{title}</title>
 
     <!-- DNS prefetch for external domains -->
     <link rel="dns-prefetch" href="//cdn.jsdelivr.net" />

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -17,7 +17,12 @@ if (!manifesto) {
 const { Content: ManifestoContent } = await manifesto.render();
 ---
 
-<ContentLayout title="About">
+<ContentLayout
+  title="About"
+  description="About Lucas Barbosa"
+  url="/about"
+  type="profile"
+>
   <section>
     <Title>About me...</Title>
   </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,7 +3,12 @@ import RootLayout from "@layouts/RootLayout.astro";
 import Tetris from "@components/Tetris/Tetris.astro";
 ---
 
-<RootLayout title="Lucas Barbosa">
+<RootLayout
+  title="Lucas Barbosa"
+  description="Personal website and blog of Lucas Barbosa."
+  url="/"
+  type="website"
+>
   <div
     class="splash flex items-center justify-center overflow-hidden min-h-dvh"
   >

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -31,7 +31,13 @@ export async function getStaticPaths() {
 }
 ---
 
-<ContentLayout title={entry.data.title}>
+<ContentLayout
+  title={entry.data.title}
+  description={entry.data.description ?? undefined}
+  url={`/posts/${entry.slug}`}
+  publishedTime={entry.data.date.toISOString?.()}
+  type="article"
+>
   <header class="mb-xl">
     <div class="my-lg">
       <a

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -10,7 +10,12 @@ dayjs.extend(relativeTime);
 const posts = await getCollection("blog");
 ---
 
-<ContentLayout title="Posts">
+<ContentLayout
+  title="Posts"
+  description="All posts by Lucas Barbosa"
+  url="/posts"
+  type="website"
+>
   <section class="font-mono">
     <Title>Posts</Title>
     <p class="mb-3xl">Toward escape velocity</p>


### PR DESCRIPTION
## Summary
- add a reusable SEO component that renders canonical links along with OpenGraph and Twitter metadata
- update RootLayout to consume SEO props and ensure canonical URLs resolve against the configured site
- provide page-specific metadata for home, about, posts index, and individual posts using existing content data
- default SEO image falls back to the favicon when a page does not specify one

## Testing
- npm run build *(fails: missing TURSO_DB_URL or TURSO_DB_AUTH_TOKEN for visitor-count API during build)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69496efe68c0832097af265e21a4409c)