### PR TITLE
Add JSON-LD structured data to blog posts

### DIFF
--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -25,10 +25,6 @@ const publishedDate = entry.data.date;
 const modifiedDate =
   (entry.data as { updated?: Date }).updated ?? publishedDate;
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
-const heroImage =
-  (entry.data as { heroImage?: string; image?: string }).heroImage ??
-  (entry.data as { heroImage?: string; image?: string }).image;
-const heroImageUrl = heroImage ? new URL(heroImage, Astro.site).toString() : undefined;
 
 const jsonLd = JSON.stringify(
   {
@@ -43,7 +39,6 @@ const jsonLd = JSON.stringify(
     datePublished: publishedDate.toISOString(),
     dateModified: modifiedDate.toISOString(),
     url: canonicalUrl.toString(),
-    image: heroImageUrl,
   },
   null,
   2

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -21,6 +21,33 @@ if (!entry) {
 }
 
 const { Content } = await entry.render();
+const publishedDate = entry.data.date;
+const modifiedDate =
+  (entry.data as { updated?: Date }).updated ?? publishedDate;
+const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
+const heroImage =
+  (entry.data as { heroImage?: string; image?: string }).heroImage ??
+  (entry.data as { heroImage?: string; image?: string }).image;
+const heroImageUrl = heroImage ? new URL(heroImage, Astro.site).toString() : undefined;
+
+const jsonLd = JSON.stringify(
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: entry.data.title,
+    description: entry.data.description,
+    author: {
+      "@type": "Person",
+      name: entry.data.author,
+    },
+    datePublished: publishedDate.toISOString(),
+    dateModified: modifiedDate.toISOString(),
+    url: canonicalUrl.toString(),
+    image: heroImageUrl,
+  },
+  null,
+  2
+);
 
 // Define getStaticPaths to generate paths for all blog posts
 export async function getStaticPaths() {
@@ -53,6 +80,7 @@ export async function getStaticPaths() {
       </div>
     </p>
   </header>
+  <script type="application/ld+json" is:inline>{jsonLd}</script>
   <section class="blog-content content">
     <Content />
   </section>


### PR DESCRIPTION
## Summary
- add BlogPosting JSON-LD metadata to post pages
- include canonical URL, dates, author, and optional hero image details

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949725292bc8320865d61535d598853)