### PR TITLE
Add SEO metadata to posts index

### DIFF
--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -7,13 +7,21 @@ import Title from "@components/Title.astro";
 import ReadingTime from "@components/ReadingTime.astro";
 dayjs.extend(relativeTime);
 
-const posts = await getCollection("blog");
+const pageTitle = "All Posts | Lucas Barbosa";
+const pageDescription =
+  "Browse the full archive of Lucas Barbosa's writing, sorted by recency with reading times.";
+// Keep canonicalPath per page (e.g., /posts/page/2) if pagination/filters are added.
+const canonicalPath = "/posts";
+
+const posts = (await getCollection("blog")).sort((a, b) =>
+  dayjs(a.data.date).isBefore(dayjs(b.data.date)) ? 1 : -1
+);
 ---
 
 <ContentLayout
-  title="Posts"
-  description="All posts by Lucas Barbosa"
-  url="/posts"
+  title={pageTitle}
+  description={pageDescription}
+  url={canonicalPath}
   type="website"
 >
   <section class="font-mono">
@@ -22,25 +30,21 @@ const posts = await getCollection("blog");
   </section>
   <section class="font-mono">
     {
-      posts
-        .sort((a, b) =>
-          dayjs(a.data.date).isBefore(dayjs(b.data.date)) ? 1 : -1
-        )
-        .map((p) => (
-          <div class="flex flex-col gap-sm mb-xl">
-            <a
-              class="hover:underline focus:underline visited:text-purple-600 truncate"
-              href={"/posts/" + p.slug}
-            >
-              {p.data.title.trim()}
-            </a>
-            <div class="text-gray-700 dark:text-gray-400 text-xs">
-              <ReadingTime content={p.body} />
-              <span class="font-sans">•</span>
-              <span>{dayjs(p.data.date).toNow(true)} ago</span>
-            </div>
+      posts.map((p) => (
+        <div class="flex flex-col gap-sm mb-xl">
+          <a
+            class="hover:underline focus:underline visited:text-purple-600 truncate"
+            href={"/posts/" + p.slug}
+          >
+            {p.data.title.trim()}
+          </a>
+          <div class="text-gray-700 dark:text-gray-400 text-xs">
+            <ReadingTime content={p.body} />
+            <span class="font-sans">•</span>
+            <span>{dayjs(p.data.date).toNow(true)} ago</span>
           </div>
-        ))
+        </div>
+      ))
     }
   </section>
 </ContentLayout>


### PR DESCRIPTION
## Summary
- add specific title, description, and canonical path metadata for the posts index
- reuse a single sorted posts collection to simplify rendering
- document canonical expectations for future pagination or filters

## Testing
- `bunx --bun astro check` *(fails: Missing module '@astrojs/sitemap' in current environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949775588908320af7d5752dcaf3647)