### PR TITLE
Use absolute dates on blog pages

### DIFF
--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -2,11 +2,9 @@
 import { getCollection, getEntry } from "astro:content";
 import ContentLayout from "@layouts/ContentLayout.astro";
 import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
 import Title from "@components/Title.astro";
 import ReadingTime from "@/components/ReadingTime.astro";
 import WordCount from "@/components/WordCount.astro";
-dayjs.extend(relativeTime);
 
 type Props = {
   title: string;
@@ -25,6 +23,7 @@ const publishedDate = entry.data.date;
 const modifiedDate =
   (entry.data as { updated?: Date }).updated ?? publishedDate;
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
+const dateFormat = "MMMM D, YYYY";
 
 const jsonLd = JSON.stringify(
   {
@@ -77,7 +76,7 @@ export async function getStaticPaths() {
         <span>•</span>
         <ReadingTime content={entry.body} />
         <span>•</span>
-        <span>Written {dayjs(entry.data.date).toNow(true)} ago</span>
+        <span>Written {dayjs(entry.data.date).format(dateFormat)}</span>
       </div>
     </p>
   </header>

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -1,17 +1,16 @@
 ---
 import { getCollection } from "astro:content";
 import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
 import ContentLayout from "@layouts/ContentLayout.astro";
 import Title from "@components/Title.astro";
 import ReadingTime from "@components/ReadingTime.astro";
-dayjs.extend(relativeTime);
 
 const pageTitle = "All Posts | Lucas Barbosa";
 const pageDescription =
   "Browse the full archive of Lucas Barbosa's writing, sorted by recency with reading times.";
 // Keep canonicalPath per page (e.g., /posts/page/2) if pagination/filters are added.
 const canonicalPath = "/posts";
+const dateFormat = "MMMM D, YYYY";
 
 const posts = (await getCollection("blog")).sort((a, b) =>
   dayjs(a.data.date).isBefore(dayjs(b.data.date)) ? 1 : -1
@@ -41,7 +40,7 @@ const posts = (await getCollection("blog")).sort((a, b) =>
           <div class="text-gray-700 dark:text-gray-400 text-xs">
             <ReadingTime content={p.body} />
             <span class="font-sans">•</span>
-            <span>{dayjs(p.data.date).toNow(true)} ago</span>
+            <span>{dayjs(p.data.date).format(dateFormat)}</span>
           </div>
         </div>
       ))


### PR DESCRIPTION
### Motivation
- The relative date display on the blog listing and individual post pages was showing incorrect values, so the UI needs stable absolute dates instead of relative times.

### Description
- Replaced relative-time rendering with formatted absolute dates by adding a shared `dateFormat = "MMMM D, YYYY"` constant in `src/pages/posts/index.astro` and `src/pages/posts/[slug].astro`.
- Replaced `dayjs(...).toNow(true) ago` usages with `dayjs(...).format(dateFormat)` in the posts index and post template.
- Removed the unused `dayjs/plugin/relativeTime` import and the `dayjs.extend(relativeTime)` setup.
- Modified files: `src/pages/posts/index.astro` and `src/pages/posts/[slug].astro`.

### Testing
- Started the dev server with `bunx --bun astro dev --host 0.0.0.0 --port 4321` and the server started successfully.
- Visited the posts listing and several individual post pages and received `200` responses for `/posts` and the post routes. 
- Captured a screenshot of the posts listing using Playwright which produced the artifact `artifacts/posts-listing.png`, confirming the listing now shows absolute dates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69869ce707f48320bd1faf38b18aa4cc)