### PR TITLE
Add interactive Mobius strip playground and refresh bio intro

### DIFF
--- a/src/components/MobiusStrip/MobiusPlaygroundControls.tsx
+++ b/src/components/MobiusStrip/MobiusPlaygroundControls.tsx
@@ -1,0 +1,291 @@
+import { For, Show, createSignal, onCleanup, onMount } from 'solid-js';
+import type { PlaygroundColorTheme, PlaygroundSettings } from './MobiusStrip';
+
+const PLAYGROUND_EVENT_NAME = 'mobius:playground-update';
+
+type SliderKey =
+  | 'roughness'
+  | 'clearcoat'
+  | 'iridescence'
+  | 'envMapIntensity'
+  | 'exposure'
+  | 'shimmerAmplitude'
+  | 'shimmerFrequency'
+  | 'tintTemperature';
+
+interface SliderConfig {
+  key: SliderKey;
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+}
+
+const materialSliderConfigs: SliderConfig[] = [
+  { key: 'roughness', label: 'Roughness', min: 0.02, max: 0.8, step: 0.01 },
+  { key: 'clearcoat', label: 'Clearcoat', min: 0, max: 1, step: 0.01 },
+  { key: 'iridescence', label: 'Iridescence', min: 0, max: 1, step: 0.01 },
+];
+
+const themeSwatches: Array<{ id: PlaygroundColorTheme; label: string; swatchClass: string }> = [
+  { id: 'default', label: 'Default', swatchClass: 'bg-gradient-to-br from-slate-300 to-slate-500' },
+  { id: 'cool', label: 'Cool', swatchClass: 'bg-gradient-to-br from-blue-300 to-cyan-500' },
+  { id: 'violet', label: 'Violet', swatchClass: 'bg-gradient-to-br from-violet-300 to-fuchsia-500' },
+];
+
+const defaultPlaygroundValues = {
+  roughness: 0.2,
+  clearcoat: 0.66,
+  iridescence: 0.5,
+  envMapIntensity: 1.25,
+  exposure: 1.06,
+  shimmerAmplitude: 0.085,
+  shimmerFrequency: 0.55,
+  tintTemperature: 0,
+  colorTheme: 'default' as PlaygroundColorTheme,
+  highContrast: false,
+};
+
+const lightingSliderConfigs: SliderConfig[] = [
+  { key: 'exposure', label: 'Exposure', min: 0.55, max: 1.8, step: 0.01 },
+  { key: 'envMapIntensity', label: 'Env Intensity', min: 0.4, max: 2.4, step: 0.01 },
+  { key: 'shimmerAmplitude', label: 'Shimmer Amount', min: 0, max: 0.25, step: 0.005 },
+  { key: 'shimmerFrequency', label: 'Shimmer Speed', min: 0.15, max: 2.2, step: 0.01 },
+  { key: 'tintTemperature', label: 'Temperature', min: -1, max: 1, step: 0.01 },
+];
+
+export const MobiusPlaygroundControls = () => {
+  const [isOpen, setIsOpen] = createSignal(false);
+  const [roughness, setRoughness] = createSignal(defaultPlaygroundValues.roughness);
+  const [clearcoat, setClearcoat] = createSignal(defaultPlaygroundValues.clearcoat);
+  const [envMapIntensity, setEnvMapIntensity] = createSignal(defaultPlaygroundValues.envMapIntensity);
+  const [iridescence, setIridescence] = createSignal(defaultPlaygroundValues.iridescence);
+  const [colorTheme, setColorTheme] = createSignal<PlaygroundColorTheme>(defaultPlaygroundValues.colorTheme);
+  const [exposure, setExposure] = createSignal(defaultPlaygroundValues.exposure);
+  const [shimmerAmplitude, setShimmerAmplitude] = createSignal(defaultPlaygroundValues.shimmerAmplitude);
+  const [shimmerFrequency, setShimmerFrequency] = createSignal(defaultPlaygroundValues.shimmerFrequency);
+  const [tintTemperature, setTintTemperature] = createSignal(defaultPlaygroundValues.tintTemperature);
+  const [highContrast, setHighContrast] = createSignal(defaultPlaygroundValues.highContrast);
+
+  let pendingSettings: PlaygroundSettings | null = null;
+  let dispatchFrame = 0;
+
+  const applyDefaults = () => {
+    if (dispatchFrame !== 0) {
+      window.cancelAnimationFrame(dispatchFrame);
+      dispatchFrame = 0;
+    }
+    pendingSettings = null;
+
+    setRoughness(defaultPlaygroundValues.roughness);
+    setClearcoat(defaultPlaygroundValues.clearcoat);
+    setIridescence(defaultPlaygroundValues.iridescence);
+    setEnvMapIntensity(defaultPlaygroundValues.envMapIntensity);
+    setExposure(defaultPlaygroundValues.exposure);
+    setShimmerAmplitude(defaultPlaygroundValues.shimmerAmplitude);
+    setShimmerFrequency(defaultPlaygroundValues.shimmerFrequency);
+    setTintTemperature(defaultPlaygroundValues.tintTemperature);
+    setColorTheme(defaultPlaygroundValues.colorTheme);
+    setHighContrast(defaultPlaygroundValues.highContrast);
+
+    scheduleDispatch(defaultPlaygroundValues);
+  };
+
+  const scheduleDispatch = (settingsPatch: PlaygroundSettings) => {
+    pendingSettings = { ...(pendingSettings ?? {}), ...settingsPatch };
+    if (dispatchFrame !== 0) {
+      return;
+    }
+
+    dispatchFrame = window.requestAnimationFrame(() => {
+      dispatchFrame = 0;
+      if (!pendingSettings) {
+        return;
+      }
+
+      window.dispatchEvent(
+        new CustomEvent<PlaygroundSettings>(PLAYGROUND_EVENT_NAME, {
+          detail: pendingSettings,
+        }),
+      );
+      pendingSettings = null;
+    });
+  };
+
+  onMount(() => {
+    const pendingFrames: number[] = [];
+    const pendingTimeouts: number[] = [];
+    setIsOpen(window.innerWidth >= 768);
+    applyDefaults();
+    pendingFrames.push(window.requestAnimationFrame(() => {
+      applyDefaults();
+      pendingFrames.push(window.requestAnimationFrame(() => applyDefaults()));
+    }));
+    pendingTimeouts.push(window.setTimeout(() => applyDefaults(), 300));
+    pendingTimeouts.push(window.setTimeout(() => applyDefaults(), 700));
+
+    const handlePageShow = () => {
+      applyDefaults();
+    };
+    window.addEventListener('pageshow', handlePageShow);
+
+    onCleanup(() => {
+      for (const frame of pendingFrames) {
+        window.cancelAnimationFrame(frame);
+      }
+      for (const timeoutId of pendingTimeouts) {
+        window.clearTimeout(timeoutId);
+      }
+      window.removeEventListener('pageshow', handlePageShow);
+    });
+  });
+
+  onCleanup(() => {
+    if (dispatchFrame !== 0) {
+      window.cancelAnimationFrame(dispatchFrame);
+    }
+  });
+
+  const sliderValues = () => ({
+    roughness: roughness(),
+    clearcoat: clearcoat(),
+    envMapIntensity: envMapIntensity(),
+    iridescence: iridescence(),
+    exposure: exposure(),
+    shimmerAmplitude: shimmerAmplitude(),
+    shimmerFrequency: shimmerFrequency(),
+    tintTemperature: tintTemperature(),
+  });
+
+  const updateSlider = (key: SliderKey) => (
+    event: InputEvent & { currentTarget: HTMLInputElement },
+  ) => {
+    const nextValue = Number(event.currentTarget.value);
+    if (key === 'roughness') setRoughness(nextValue);
+    if (key === 'clearcoat') setClearcoat(nextValue);
+    if (key === 'envMapIntensity') setEnvMapIntensity(nextValue);
+    if (key === 'iridescence') setIridescence(nextValue);
+    if (key === 'exposure') setExposure(nextValue);
+    if (key === 'shimmerAmplitude') setShimmerAmplitude(nextValue);
+    if (key === 'shimmerFrequency') setShimmerFrequency(nextValue);
+    if (key === 'tintTemperature') setTintTemperature(nextValue);
+    scheduleDispatch({ [key]: nextValue });
+  };
+
+  const selectTheme = (theme: PlaygroundColorTheme) => {
+    setColorTheme(theme);
+    scheduleDispatch({ colorTheme: theme });
+  };
+
+  const toggleHighContrast = () => {
+    const nextValue = !highContrast();
+    setHighContrast(nextValue);
+    scheduleDispatch({ highContrast: nextValue });
+  };
+
+  return (
+    <aside class="pointer-events-none fixed left-1/2 top-20 z-30 flex w-[calc(100vw-2rem)] -translate-x-1/2 flex-col items-end sm:top-24 md:w-[100vw] md:max-w-[42rem]">
+      <button
+        type="button"
+        class="pointer-events-auto mb-2 inline-flex items-center gap-2 rounded-full border border-shark-950/10 bg-ivory/75 px-3 py-1.5 text-xs font-medium text-shark-800 shadow-sm backdrop-blur-md transition-colors hover:bg-ivory/85 dark:border-ivory/15 dark:bg-shark-950/75 dark:text-ivory dark:hover:bg-shark-950/85"
+        onClick={() => setIsOpen((value) => !value)}
+        aria-expanded={isOpen()}
+        aria-controls="mobius-playground-panel"
+      >
+        Playground
+      </button>
+
+      <Show when={isOpen()}>
+        <section
+          id="mobius-playground-panel"
+          class="pointer-events-auto w-[min(20rem,calc(100vw-2rem))] max-h-[calc(100dvh-7.5rem)] overflow-y-auto rounded-2xl border border-shark-950/10 bg-ivory/70 p-3 shadow-lg backdrop-blur-md dark:border-ivory/10 dark:bg-shark-950/70 sm:max-h-none sm:overflow-visible"
+        >
+          <div class="mb-3">
+            <p class="text-[11px] font-semibold uppercase tracking-[0.08em] text-shark-700/85 dark:text-shark-200/85">
+              Material shine
+            </p>
+            <div class="mt-2 space-y-2.5">
+              <For each={materialSliderConfigs}>
+                {(slider) => (
+                  <label class="block">
+                    <span class="mb-1 block text-xs text-shark-700 dark:text-shark-200">{slider.label}</span>
+                    <input
+                      type="range"
+                      min={slider.min}
+                      max={slider.max}
+                      step={slider.step}
+                      value={sliderValues()[slider.key]}
+                      onInput={updateSlider(slider.key)}
+                      class="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-shark-950/15 accent-shark-900 dark:bg-ivory/15 dark:accent-ivory"
+                    />
+                  </label>
+                )}
+              </For>
+            </div>
+          </div>
+
+          <div class="mb-3">
+            <p class="text-[11px] font-semibold uppercase tracking-[0.08em] text-shark-700/85 dark:text-shark-200/85">
+              Lighting
+            </p>
+            <div class="mt-2 space-y-2.5">
+              <For each={lightingSliderConfigs}>
+                {(slider) => (
+                  <label class="block">
+                    <span class="mb-1 block text-xs text-shark-700 dark:text-shark-200">{slider.label}</span>
+                    <input
+                      type="range"
+                      min={slider.min}
+                      max={slider.max}
+                      step={slider.step}
+                      value={sliderValues()[slider.key]}
+                      onInput={updateSlider(slider.key)}
+                      class="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-shark-950/15 accent-shark-900 dark:bg-ivory/15 dark:accent-ivory"
+                    />
+                  </label>
+                )}
+              </For>
+            </div>
+            <button
+              type="button"
+              onClick={toggleHighContrast}
+              class={`mt-3 w-full rounded-md border px-2 py-1.5 text-xs transition-colors ${
+                highContrast()
+                  ? 'border-shark-950/70 bg-shark-950/10 text-shark-900 dark:border-ivory/70 dark:bg-ivory/15 dark:text-ivory'
+                  : 'border-shark-950/15 bg-ivory/50 text-shark-700 dark:border-ivory/20 dark:bg-shark-950/50 dark:text-shark-200'
+              }`}
+              aria-pressed={highContrast()}
+            >
+              High Contrast {highContrast() ? 'On' : 'Off'}
+            </button>
+          </div>
+
+          <div>
+            <p class="text-[11px] font-semibold uppercase tracking-[0.08em] text-shark-700/85 dark:text-shark-200/85">
+              Color theme
+            </p>
+            <div class="mt-2 grid grid-cols-3 gap-2">
+              <For each={themeSwatches}>
+                {(theme) => (
+                  <button
+                    type="button"
+                    onClick={() => selectTheme(theme.id)}
+                    class={`rounded-md border p-2 transition-colors ${
+                      colorTheme() === theme.id
+                        ? 'border-shark-950/70 dark:border-ivory/70'
+                        : 'border-shark-950/15 dark:border-ivory/20'
+                    }`}
+                    aria-label={`Set ${theme.label} theme`}
+                  >
+                    <span class={`block h-6 rounded ${theme.swatchClass}`}></span>
+                    <span class="mt-1 block text-[10px] text-shark-700 dark:text-shark-200">{theme.label}</span>
+                  </button>
+                )}
+              </For>
+            </div>
+          </div>
+        </section>
+      </Show>
+    </aside>
+  );
+};

--- a/src/components/MobiusStrip/MobiusStrip.astro
+++ b/src/components/MobiusStrip/MobiusStrip.astro
@@ -1,9 +1,15 @@
 ---
 import { MobiusStripRenderer } from "@/components/MobiusStrip/MobiusStripRenderer";
+
+interface Props {
+  interactive?: boolean;
+}
+
+const { interactive = false } = Astro.props as Props;
 ---
 
-<canvas id="webgl"></canvas>
-<MobiusStripRenderer client:idle />
+<canvas id="webgl" data-interactive={interactive ? "true" : undefined}></canvas>
+<MobiusStripRenderer client:idle interactive={interactive} />
 
 <style>
   canvas#webgl {
@@ -15,5 +21,11 @@ import { MobiusStripRenderer } from "@/components/MobiusStrip/MobiusStripRendere
     height: 100%;
     z-index: 1;
     pointer-events: none;
+  }
+
+  canvas#webgl[data-interactive="true"] {
+    pointer-events: auto;
+    cursor: grab;
+    touch-action: none;
   }
 </style>

--- a/src/components/MobiusStrip/MobiusStrip.ts
+++ b/src/components/MobiusStrip/MobiusStrip.ts
@@ -26,6 +26,31 @@ interface GeometryDetail {
   rows: number;
 }
 
+interface MobiusStripOptions {
+  interactive?: boolean;
+}
+
+export type PlaygroundColorTheme = 'default' | 'cool' | 'violet';
+
+export interface PlaygroundSettings {
+  roughness?: number;
+  clearcoat?: number;
+  envMapIntensity?: number;
+  iridescence?: number;
+  colorTheme?: PlaygroundColorTheme;
+  exposure?: number;
+  shimmerAmplitude?: number;
+  shimmerFrequency?: number;
+  tintTemperature?: number;
+  highContrast?: boolean;
+}
+
+interface PlaygroundColorProfile {
+  color: number;
+  sheenColor: number;
+  specularColor: number;
+}
+
 const LIGHT_CHROME_PROFILE: ChromeProfile = {
   color: 0xc6d0df,
   roughness: 0.2,
@@ -64,9 +89,23 @@ const DARK_CHROME_PROFILE: ChromeProfile = {
   shimmerFrequency: 0.68,
 };
 
+const PLAYGROUND_COLOR_PROFILES: Record<'cool' | 'violet', PlaygroundColorProfile> = {
+  cool: {
+    color: 0xc2d9ff,
+    sheenColor: 0xbcdcff,
+    specularColor: 0xdeecff,
+  },
+  violet: {
+    color: 0xd6c5ff,
+    sheenColor: 0xcbb1ff,
+    specularColor: 0xe3d8ff,
+  },
+};
+
 export class MobiusStrip {
   private static readonly geometryCache = new Map<string, THREE.BufferGeometry>();
 
+  private readonly canvas: HTMLCanvasElement;
   private scene: THREE.Scene;
   private camera: THREE.PerspectiveCamera;
   private renderer: THREE.WebGLRenderer;
@@ -95,12 +134,25 @@ export class MobiusStrip {
   private readonly introOrbitZ = -0.38;
   private readonly introStartYOffset: number;
   private readonly geometryCacheKey: string;
+  private readonly isInteractive: boolean;
+  private playgroundSettings: PlaygroundSettings = {};
+  private dynamicEnvMapBase = LIGHT_CHROME_PROFILE.envMapIntensity;
+  private dynamicIridescenceBase = LIGHT_CHROME_PROFILE.iridescence;
+  private dynamicShimmerAmplitude = LIGHT_CHROME_PROFILE.shimmerAmplitude;
+  private dynamicShimmerFrequency = LIGHT_CHROME_PROFILE.shimmerFrequency;
+  private activePointerId: number | null = null;
+  private isDragging = false;
+  private dragLastX = 0;
+  private dragLastY = 0;
+  private readonly dragSensitivity = 0.0042;
 
   private readonly radius = 2.3;
   private readonly stripWidth = 1.05;
   private readonly stripThickness = 0.16;
 
-  constructor(canvas: HTMLCanvasElement) {
+  constructor(canvas: HTMLCanvasElement, options: MobiusStripOptions = {}) {
+    this.canvas = canvas;
+    this.isInteractive = options.interactive ?? false;
     this.scene = new THREE.Scene();
 
     const { width: w, height: h } = this.getViewportSize();
@@ -112,7 +164,7 @@ export class MobiusStrip {
     this.introStartYOffset = this.computeIntroStartYOffset();
 
     this.renderer = new THREE.WebGLRenderer({
-      canvas,
+      canvas: this.canvas,
       alpha: true,
       antialias: false,
       powerPreference: 'low-power',
@@ -169,31 +221,175 @@ export class MobiusStrip {
     this.resizeHandler = () => this.onResize();
     window.addEventListener('resize', this.resizeHandler);
     this.observeThemeChanges();
+    this.bindPointerInteraction();
 
     this.loadEnvironmentMap();
     this.animate();
   }
 
-  private updateThemeMaterial(): void {
-    const isDarkMode = document.documentElement.classList.contains('dark');
-    this.chromeProfile = isDarkMode ? DARK_CHROME_PROFILE : LIGHT_CHROME_PROFILE;
-    const profile = this.chromeProfile;
+  private bindPointerInteraction(): void {
+    if (!this.isInteractive) {
+      return;
+    }
 
-    this.material.color.set(profile.color);
-    this.material.roughness = profile.roughness;
-    this.material.clearcoat = profile.clearcoat;
+    this.canvas.addEventListener('pointerdown', this.handlePointerDown);
+    this.canvas.addEventListener('pointermove', this.handlePointerMove);
+    this.canvas.addEventListener('pointerup', this.handlePointerUpOrCancel);
+    this.canvas.addEventListener('pointercancel', this.handlePointerUpOrCancel);
+  }
+
+  private unbindPointerInteraction(): void {
+    if (!this.isInteractive) {
+      return;
+    }
+
+    this.canvas.removeEventListener('pointerdown', this.handlePointerDown);
+    this.canvas.removeEventListener('pointermove', this.handlePointerMove);
+    this.canvas.removeEventListener('pointerup', this.handlePointerUpOrCancel);
+    this.canvas.removeEventListener('pointercancel', this.handlePointerUpOrCancel);
+  }
+
+  private handlePointerDown = (event: PointerEvent): void => {
+    if (event.button !== 0 || this.activePointerId !== null) {
+      return;
+    }
+
+    event.preventDefault();
+    this.isDragging = true;
+    this.activePointerId = event.pointerId;
+    this.dragLastX = event.clientX;
+    this.dragLastY = event.clientY;
+    this.canvas.style.cursor = 'grabbing';
+    this.canvas.setPointerCapture(event.pointerId);
+  };
+
+  private handlePointerMove = (event: PointerEvent): void => {
+    if (!this.isDragging || this.activePointerId !== event.pointerId) {
+      return;
+    }
+
+    const deltaX = event.clientX - this.dragLastX;
+    const deltaY = event.clientY - this.dragLastY;
+    this.dragLastX = event.clientX;
+    this.dragLastY = event.clientY;
+
+    this.mesh.rotation.y += deltaX * this.dragSensitivity;
+    this.mesh.rotation.x += deltaY * this.dragSensitivity;
+  };
+
+  private handlePointerUpOrCancel = (event: PointerEvent): void => {
+    if (this.activePointerId !== event.pointerId) {
+      return;
+    }
+
+    this.isDragging = false;
+    this.activePointerId = null;
+    this.canvas.style.cursor = 'grab';
+
+    if (this.canvas.hasPointerCapture(event.pointerId)) {
+      this.canvas.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  private clampRange(value: number, min: number, max: number): number {
+    return Math.min(max, Math.max(min, value));
+  }
+
+  private applyTintTemperature(colorHex: number, tintTemperature: number): number {
+    const color = new THREE.Color(colorHex);
+    const clampedTemperature = this.clampRange(tintTemperature, -1, 1);
+    const warmStrength = Math.max(0, clampedTemperature);
+    const coolStrength = Math.max(0, -clampedTemperature);
+
+    const red = this.clampRange(color.r + (warmStrength * 0.14) - (coolStrength * 0.06), 0, 1);
+    const green = this.clampRange(color.g + (warmStrength * 0.03) - (coolStrength * 0.01), 0, 1);
+    const blue = this.clampRange(color.b + (coolStrength * 0.14) - (warmStrength * 0.09), 0, 1);
+
+    color.setRGB(red, green, blue);
+    return color.getHex();
+  }
+
+  private getThemeColorProfile(baseProfile: ChromeProfile): PlaygroundColorProfile {
+    const colorTheme = this.playgroundSettings.colorTheme ?? 'default';
+    if (colorTheme === 'default') {
+      return {
+        color: baseProfile.color,
+        sheenColor: baseProfile.sheenColor,
+        specularColor: baseProfile.specularColor,
+      };
+    }
+
+    return PLAYGROUND_COLOR_PROFILES[colorTheme];
+  }
+
+  private applyThemeMaterial(): void {
+    const profile = this.chromeProfile;
+    const themeColorProfile = this.getThemeColorProfile(profile);
+    const roughness = this.playgroundSettings.roughness === undefined
+      ? profile.roughness
+      : this.clampRange(this.playgroundSettings.roughness, 0.02, 0.8);
+    const clearcoat = this.playgroundSettings.clearcoat === undefined
+      ? profile.clearcoat
+      : this.clampRange(this.playgroundSettings.clearcoat, 0, 1);
+    const envMapIntensity = this.playgroundSettings.envMapIntensity === undefined
+      ? profile.envMapIntensity
+      : this.clampRange(this.playgroundSettings.envMapIntensity, 0.4, 2.4);
+    const iridescence = this.playgroundSettings.iridescence === undefined
+      ? profile.iridescence
+      : this.clampRange(this.playgroundSettings.iridescence, 0, 1);
+    const toneMappingExposure = this.playgroundSettings.exposure === undefined
+      ? profile.toneMappingExposure
+      : this.clampRange(this.playgroundSettings.exposure, 0.55, 1.8);
+    const shimmerAmplitude = this.playgroundSettings.shimmerAmplitude === undefined
+      ? profile.shimmerAmplitude
+      : this.clampRange(this.playgroundSettings.shimmerAmplitude, 0, 0.25);
+    const shimmerFrequency = this.playgroundSettings.shimmerFrequency === undefined
+      ? profile.shimmerFrequency
+      : this.clampRange(this.playgroundSettings.shimmerFrequency, 0.15, 2.2);
+    const tintTemperature = this.playgroundSettings.tintTemperature === undefined
+      ? 0
+      : this.clampRange(this.playgroundSettings.tintTemperature, -1, 1);
+    const isHighContrast = this.playgroundSettings.highContrast ?? false;
+    const contrastedRoughness = isHighContrast ? Math.max(0.04, roughness * 0.68) : roughness;
+    const contrastedClearcoat = isHighContrast ? this.clampRange(clearcoat + 0.08, 0, 1) : clearcoat;
+    const contrastedEnvMapIntensity = isHighContrast
+      ? this.clampRange(envMapIntensity * 1.14, 0.4, 2.4)
+      : envMapIntensity;
+    const contrastedIridescence = isHighContrast
+      ? this.clampRange(iridescence * 0.92, 0, 1)
+      : iridescence;
+    const colorHex = this.applyTintTemperature(themeColorProfile.color, tintTemperature);
+    const sheenColorHex = this.applyTintTemperature(themeColorProfile.sheenColor, tintTemperature);
+    const specularColorHex = this.applyTintTemperature(themeColorProfile.specularColor, tintTemperature);
+    const specularIntensity = isHighContrast
+      ? this.clampRange(profile.specularIntensity + 0.1, 0, 1.2)
+      : profile.specularIntensity;
+
+    this.material.color.set(colorHex);
+    this.material.roughness = contrastedRoughness;
+    this.material.clearcoat = contrastedClearcoat;
     this.material.clearcoatRoughness = profile.clearcoatRoughness;
-    this.material.envMapIntensity = profile.envMapIntensity;
-    this.material.iridescence = profile.iridescence;
+    this.material.envMapIntensity = contrastedEnvMapIntensity;
+    this.material.iridescence = contrastedIridescence;
     this.material.iridescenceIOR = profile.iridescenceIOR;
     this.material.iridescenceThicknessRange = profile.iridescenceThicknessRange;
     this.material.sheen = profile.sheen;
     this.material.sheenRoughness = profile.sheenRoughness;
-    this.material.sheenColor.set(profile.sheenColor);
-    this.material.specularIntensity = profile.specularIntensity;
-    this.material.specularColor.set(profile.specularColor);
+    this.material.sheenColor.set(sheenColorHex);
+    this.material.specularIntensity = specularIntensity;
+    this.material.specularColor.set(specularColorHex);
 
-    this.renderer.toneMappingExposure = profile.toneMappingExposure;
+    this.dynamicEnvMapBase = contrastedEnvMapIntensity;
+    this.dynamicIridescenceBase = contrastedIridescence;
+    this.dynamicShimmerAmplitude = shimmerAmplitude;
+    this.dynamicShimmerFrequency = shimmerFrequency;
+    this.renderer.toneMappingExposure = toneMappingExposure;
+  }
+
+  private updateThemeMaterial(): void {
+    const isDarkMode = document.documentElement.classList.contains('dark');
+    this.chromeProfile = isDarkMode ? DARK_CHROME_PROFILE : LIGHT_CHROME_PROFILE;
+    this.applyThemeMaterial();
   }
 
   private observeThemeChanges(): void {
@@ -486,16 +682,16 @@ export class MobiusStrip {
 
   private applyDynamicChrome(elapsedSeconds: number): void {
     if (this.isReducedMotion || this.isPageHidden) {
-      this.material.envMapIntensity = this.chromeProfile.envMapIntensity;
-      this.material.iridescence = this.chromeProfile.iridescence;
+      this.material.envMapIntensity = this.dynamicEnvMapBase;
+      this.material.iridescence = this.dynamicIridescenceBase;
       return;
     }
 
-    const shimmerWave = Math.sin(elapsedSeconds * this.chromeProfile.shimmerFrequency);
-    const shimmer = 1 + shimmerWave * this.chromeProfile.shimmerAmplitude;
+    const shimmerWave = Math.sin(elapsedSeconds * this.dynamicShimmerFrequency);
+    const shimmer = 1 + shimmerWave * this.dynamicShimmerAmplitude;
 
-    this.material.envMapIntensity = this.chromeProfile.envMapIntensity * shimmer;
-    this.material.iridescence = this.chromeProfile.iridescence + shimmerWave * 0.025;
+    this.material.envMapIntensity = this.dynamicEnvMapBase * shimmer;
+    this.material.iridescence = this.dynamicIridescenceBase + shimmerWave * 0.025;
   }
 
   private animate(): void {
@@ -543,6 +739,7 @@ export class MobiusStrip {
 
     cancelAnimationFrame(this.animationId);
     window.removeEventListener('resize', this.resizeHandler);
+    this.unbindPointerInteraction();
     this.themeObserver?.disconnect();
     this.unbindMotionSignals();
     this.themeObserver = null;
@@ -560,5 +757,14 @@ export class MobiusStrip {
     }
     this.material.dispose();
     this.renderer.dispose();
+  }
+
+  public applyPlaygroundSettings(settings: PlaygroundSettings): void {
+    this.playgroundSettings = {
+      ...this.playgroundSettings,
+      ...settings,
+    };
+
+    this.applyThemeMaterial();
   }
 }

--- a/src/components/MobiusStrip/MobiusStripRenderer.tsx
+++ b/src/components/MobiusStrip/MobiusStripRenderer.tsx
@@ -1,23 +1,54 @@
 import { onMount, onCleanup } from 'solid-js';
 import { MobiusStrip } from './MobiusStrip';
+import type { PlaygroundSettings } from './MobiusStrip';
+
+const PLAYGROUND_EVENT_NAME = 'mobius:playground-update';
+
+interface MobiusStripRendererProps {
+  interactive?: boolean;
+}
+
+const isPlaygroundSettings = (value: unknown): value is PlaygroundSettings => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  return true;
+};
 
 let mobiusStrip: MobiusStrip | null = null;
 
-export const MobiusStripRenderer = () => {
+export const MobiusStripRenderer = (props: MobiusStripRendererProps) => {
   onMount(() => {
     if (typeof document === 'undefined') return;
 
-    const canvas = document.querySelector('#webgl') as HTMLCanvasElement;
-    if (canvas) {
-      mobiusStrip = new MobiusStrip(canvas);
-    }
-  });
+    const handlePlaygroundUpdate = (event: Event) => {
+      if (!(event instanceof CustomEvent)) {
+        return;
+      }
 
-  onCleanup(() => {
-    if (mobiusStrip) {
-      mobiusStrip.dispose();
-      mobiusStrip = null;
+      const detail: unknown = event.detail;
+      if (!mobiusStrip || !isPlaygroundSettings(detail)) {
+        return;
+      }
+
+      mobiusStrip.applyPlaygroundSettings(detail);
+    };
+
+    window.addEventListener(PLAYGROUND_EVENT_NAME, handlePlaygroundUpdate);
+
+    const canvas = document.querySelector<HTMLCanvasElement>('#webgl');
+    if (canvas) {
+      mobiusStrip = new MobiusStrip(canvas, { interactive: props.interactive ?? false });
     }
+
+    onCleanup(() => {
+      window.removeEventListener(PLAYGROUND_EVENT_NAME, handlePlaygroundUpdate);
+
+      if (mobiusStrip) {
+        mobiusStrip.dispose();
+        mobiusStrip = null;
+      }
+    });
   });
 
   return null;

--- a/src/content/about/bio-intro.mdx
+++ b/src/content/about/bio-intro.mdx
@@ -6,9 +6,7 @@ I'm an engineer, researcher and product designer.
 
 I currently live in Sydney. I grew up in Brazil and previously studied at UNSW.
 
-Recently left my job at <a href="https://www.pwc.com/" target="_blank" rel="noopener noreferrer">PwC</a> to 
-go all-in on AI and robotics. I dabbled in fusion research as an undergrad, but decided the inflection
-point for robotics is much closer, so I wrote an <a href="https://r2.lbxa.net/thesis.pdf" target="_blank" rel="noopener noreferrer">100-page thesis</a> on post-training robots.
+I dabbled in fusion research as an undergrad, but realised the inflection point for robotics is much closer, so I recently left my job at <a href="https://www.pwc.com/" target="_blank" rel="noopener noreferrer">PwC</a> to go all-in. I wrote an 100-page <a href="https://r2.lbxa.net/thesis.pdf" target="_blank" rel="noopener noreferrer">honours thesis</a> on post-training robots.
 
 As a deep generalist with experience, I've built vertically integrated systems, from large-scale document ingestion platforms to real-time machine learning running on-device:
 

--- a/src/pages/mobius.astro
+++ b/src/pages/mobius.astro
@@ -1,5 +1,6 @@
 ---
 import MobiusStrip from "@components/MobiusStrip/MobiusStrip.astro";
+import { MobiusPlaygroundControls } from "@components/MobiusStrip/MobiusPlaygroundControls";
 import RootLayout from "@layouts/RootLayout.astro";
 ---
 
@@ -10,9 +11,10 @@ import RootLayout from "@layouts/RootLayout.astro";
   type="website"
   noIndex
 >
-  <MobiusStrip />
+  <MobiusStrip interactive />
+  <MobiusPlaygroundControls client:load />
 
-  <main class="relative z-20 min-h-dvh pt-24">
+  <main class="pointer-events-none relative z-20 min-h-dvh pt-24">
     <h1 class="sr-only">Mobius Strip Showcase</h1>
   </main>
 </RootLayout>


### PR DESCRIPTION
## Summary

- Adds an interactive playground to `/mobius`: drag-to-rotate the strip and tune material, lighting, and color settings via a collapsible control panel
- Introduces `MobiusPlaygroundControls` with sliders for roughness, clearcoat, iridescence, exposure, env intensity, shimmer, and temperature, plus color theme swatches (default, cool, violet) and a high-contrast toggle
- Wires playground settings from SolidJS controls to the Three.js renderer through a `mobius:playground-update` custom event, with rAF-batched updates to keep slider interaction smooth
- Enables pointer interaction on the canvas only when `interactive` is passed to `MobiusStrip`; the homepage embed stays non-interactive
- Rewords the about bio paragraph to lead with the robotics thesis and PwC transition

## Test plan

- [ ] Visit `/mobius` and confirm the strip renders with the playground panel open on desktop (≥768px)
- [ ] Drag the canvas to rotate the Mobius strip; cursor should switch between grab and grabbing
- [ ] Adjust material, lighting, and color theme sliders and confirm the strip updates live
- [ ] Toggle high contrast and verify the material response changes
- [ ] Collapse/expand the Playground panel on mobile and confirm controls remain usable
- [ ] Confirm the homepage Mobius strip is still non-interactive (no drag, no pointer events on canvas)
- [ ] Check the about page bio intro reads correctly and links still work
- [ ] Run `bun run astro check` — passes with 0 errors


Made with [Cursor](https://cursor.com)